### PR TITLE
adding node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-backend/.env
+backend/.envcan 
+node_modules/


### PR DESCRIPTION
package.json already defines all the packages that will be downloaded, there is no need for node_modules to be cloned as it is dependent on package.json